### PR TITLE
Retrieve args form message as array ; Allow wildcards in server blocks

### DIFF
--- a/src/osc-crystal/message.cr
+++ b/src/osc-crystal/message.cr
@@ -92,6 +92,24 @@ module OSC
       end
     end
 
+    def args : Array(Type::Types)
+      (0...nargs).map do |i|
+        case ret = arg(i)
+          # These types can be returned as-is:
+          when Array(UInt8), Char, Float32, Float64, Int32, Int64, Type::Inf, Type::Midi, Type::RGBA, String, Time, Nil
+            ret
+          # These need(?) mapping from the class types.
+          when Type::False.class
+            Type::False.new
+          when Type::Inf.class
+            Type::Inf.new
+          when Type::True.class
+            Type::True.new
+        end
+      end
+
+    end
+
     def [](index : Int)
       arg(index)
     end

--- a/src/osc-crystal/server.cr
+++ b/src/osc-crystal/server.cr
@@ -28,7 +28,11 @@ module OSC
           else
             m = OSC::Message.new(str.bytes)
             @methods_for_message.each do |address, method|
-              if File.match?(m.address, address)
+              if    File.match?(m.address,   address)
+                # Matchs a wildcard in the message address against the server filter
+                spawn method.call(m)
+              elsif File.match?(  address, m.address)
+                # Matchs a wildcard in the server filter against the message address
                 spawn method.call(m)
               end
             end


### PR DESCRIPTION
Hi,

First edit is pretty trivial, I just wanted to spit out all args quickly in my block for debugging purposes. Seems some of them return the type rather than an instance, so I've put in a type-case statement, feel free to edit if it's better to od otherwise.

Main thing was I wanted to handle a wildcard message. Looks that currently the server can match the glob in a message against all the given handlers ,but not the other way around. I.e. you would do `server.dispatch("/foo/*"){}`, so I have just added another check where this was done. I don't know if this is conformant with the spec or not, don't have time to read it right now, but I have seen something similar in other libraries. 

Cheers :)
